### PR TITLE
MC: Accelerometer, Gyroscope, Magnetometer:

### DIFF
--- a/ios/RNMotionManager/Accelerometer.h
+++ b/ios/RNMotionManager/Accelerometer.h
@@ -7,13 +7,12 @@
 #import "RCTBridgeModule.h"
 #import <CoreMotion/CoreMotion.h>
 
-@interface Accelerometer : NSObject <RCTBridgeModule> {
-  CMMotionManager *_motionManager;
-}
+@interface Accelerometer : NSObject <RCTBridgeModule>
+
 - (void) setAccelerometerUpdateInterval:(double) interval;
-- (void) getAccelerometerUpdateInterval:(RCTResponseSenderBlock) cb;
-- (void) getAccelerometerData:(RCTResponseSenderBlock) cb;
-- (void) startAccelerometerUpdates:(RCTResponseSenderBlock) cb;
+- (void) getAccelerometerUpdateInterval:(nonnull RCTResponseSenderBlock) cb;
+- (void) getAccelerometerData:(nonnull RCTResponseSenderBlock) cb;
+- (void) startAccelerometerUpdates:(nonnull RCTResponseSenderBlock) cb;
 - (void) stopAccelerometerUpdates;
 
 @end

--- a/ios/RNMotionManager/Gyroscope.h
+++ b/ios/RNMotionManager/Gyroscope.h
@@ -7,13 +7,12 @@
 #import "RCTBridgeModule.h"
 #import <CoreMotion/CoreMotion.h>
 
-@interface Gyroscope : NSObject <RCTBridgeModule> {
-    CMMotionManager *_motionManager;
-}
+@interface Gyroscope : NSObject <RCTBridgeModule>
+
 - (void) setGyroUpdateInterval:(double) interval;
-- (void) getGyroUpdateInterval:(RCTResponseSenderBlock) cb;
-- (void) getGyroData:(RCTResponseSenderBlock) cb;
-- (void) startGyroUpdates:(RCTResponseSenderBlock) cb;
+- (void) getGyroUpdateInterval:(nonnull RCTResponseSenderBlock) cb;
+- (void) getGyroData:(nonnull RCTResponseSenderBlock) cb;
+- (void) startGyroUpdates:(nonnull RCTResponseSenderBlock) cb;
 - (void) stopGyroUpdates;
 
 @end

--- a/ios/RNMotionManager/Gyroscope.m
+++ b/ios/RNMotionManager/Gyroscope.m
@@ -8,7 +8,18 @@
 #import "RCTEventDispatcher.h"
 #import "Gyroscope.h"
 
+@interface Gyroscope()
+
+@property (nonatomic, readonly, nonnull) CMMotionManager* motionManager;
+
++ (NSDictionary*) dictionaryFromGyroData:(CMGyroData*)gyroData;
+
+@end
+
+
 @implementation Gyroscope
+
+@synthesize motionManager = _motionManager;
 
 @synthesize bridge = _bridge;
 
@@ -21,11 +32,11 @@ RCT_EXPORT_MODULE();
     if (self) {
         self->_motionManager = [[CMMotionManager alloc] init];
         //Gyroscope
-        if([self->_motionManager isGyroAvailable])
+        if(self.motionManager.gyroAvailable)
         {
             NSLog(@"Gyroscope available");
             /* Start the gyroscope if it is not active already */
-            if([self->_motionManager isGyroActive] == NO)
+            if(self.motionManager.gyroActive)
             {
                 NSLog(@"Gyroscope active");
             } else {
@@ -43,63 +54,54 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(setGyroUpdateInterval:(double) interval) {
     NSLog(@"setGyroUpdateInterval: %f", interval);
 
-    [self->_motionManager setGyroUpdateInterval:interval];
+    self.motionManager.gyroUpdateInterval = interval;
 }
 
-RCT_EXPORT_METHOD(getGyroUpdateInterval:(RCTResponseSenderBlock) cb) {
-    double interval = self->_motionManager.gyroUpdateInterval;
+RCT_EXPORT_METHOD(getGyroUpdateInterval:(nonnull RCTResponseSenderBlock) cb) {
+    double interval = self.motionManager.gyroUpdateInterval;
     NSLog(@"getGyroUpdateInterval: %f", interval);
     cb(@[[NSNull null], [NSNumber numberWithDouble:interval]]);
 }
 
-RCT_EXPORT_METHOD(getGyroData:(RCTResponseSenderBlock) cb) {
-    double x = self->_motionManager.gyroData.rotationRate.x;
-    double y = self->_motionManager.gyroData.rotationRate.y;
-    double z = self->_motionManager.gyroData.rotationRate.z;
-    double timestamp = self->_motionManager.gyroData.timestamp;
+RCT_EXPORT_METHOD(getGyroData:(nonnull RCTResponseSenderBlock) cb) {
+    CMGyroData* gyroData = self.motionManager.gyroData;
+    
+    NSLog(@"getGyroData: %f, %f, %f, %f", gyroData.rotationRate.x, gyroData.rotationRate.y, gyroData.rotationRate.z, gyroData.timestamp);
 
-    NSLog(@"getGyroData: %f, %f, %f, %f", x, y, z, timestamp);
-
-    cb(@[[NSNull null], @{
-             @"rotationRate": @{
-                     @"x" : [NSNumber numberWithDouble:x],
-                     @"y" : [NSNumber numberWithDouble:y],
-                     @"z" : [NSNumber numberWithDouble:z],
-                     @"timestamp" : [NSNumber numberWithDouble:timestamp]
-                     }
-             }]
-       );
+    cb(@[ [NSNull null], [Gyroscope dictionaryFromGyroData: gyroData] ]);
 }
 
-RCT_EXPORT_METHOD(startGyroUpdates:(RCTResponseSenderBlock) cb) {
+RCT_EXPORT_METHOD(startGyroUpdates:(nonnull RCTResponseSenderBlock) cb) {
     NSLog(@"startGyroUpdates");
-    [self->_motionManager startGyroUpdates];
 
+    [self.motionManager startGyroUpdates];
+    
     /* Receive the gyroscope data on this block */
-    [self->_motionManager startGyroUpdatesToQueue:[NSOperationQueue mainQueue]
-                                      withHandler:^(CMGyroData *gyroData, NSError *error)
-     {
-         double x = gyroData.rotationRate.x;
-         double y = gyroData.rotationRate.y;
-         double z = gyroData.rotationRate.z;
-         double timestamp = gyroData.timestamp;
-         NSLog(@"startGyroUpdates: %f, %f, %f, %f", x, y, z, timestamp);
+    [self.motionManager startGyroUpdatesToQueue:[NSOperationQueue mainQueue]
+                                    withHandler:^(CMGyroData *gyroData, NSError *error)
+    {
+         NSLog(@"startGyroUpdates: %f, %f, %f, %f", gyroData.rotationRate.x, gyroData.rotationRate.y, gyroData.rotationRate.z, gyroData.timestamp);
 
-         [self.bridge.eventDispatcher sendDeviceEventWithName:@"GyroData" body:@{
-                                                                                 @"rotationRate": @{
-                                                                                         @"x" : [NSNumber numberWithDouble:x],
-                                                                                         @"y" : [NSNumber numberWithDouble:y],
-                                                                                         @"z" : [NSNumber numberWithDouble:z],
-                                                                                         @"timestamp" : [NSNumber numberWithDouble:timestamp]
-                                                                                         }
-                                                                                 }];
-     }];
+         [self.bridge.eventDispatcher sendDeviceEventWithName:@"GyroData" body: [Gyroscope dictionaryFromGyroData: gyroData]];
+    }];
+    
     cb(@[[NSNull null]]);
 }
 
 RCT_EXPORT_METHOD(stopGyroUpdates) {
     NSLog(@"stopGyroUpdates");
-    [self->_motionManager stopGyroUpdates];
+    [self.motionManager stopGyroUpdates];
+}
+
++ (NSDictionary*) dictionaryFromGyroData:(CMGyroData*)gyroData {
+    return @{
+             @"rotationRate": @{
+                     @"x" : [NSNumber numberWithDouble:gyroData.rotationRate.x],
+                     @"y" : [NSNumber numberWithDouble:gyroData.rotationRate.y],
+                     @"z" : [NSNumber numberWithDouble:gyroData.rotationRate.z],
+                     @"timestamp" : [NSNumber numberWithDouble:gyroData.timestamp]
+                     }
+             };
 }
 
 @end

--- a/ios/RNMotionManager/Magnetometer.h
+++ b/ios/RNMotionManager/Magnetometer.h
@@ -7,13 +7,12 @@
 #import "RCTBridgeModule.h"
 #import <CoreMotion/CoreMotion.h>
 
-@interface Magnetometer : NSObject <RCTBridgeModule> {
-  CMMotionManager *_motionManager;
-}
+@interface Magnetometer : NSObject <RCTBridgeModule>
+
 - (void) setMagnetometerUpdateInterval:(double) interval;
-- (void) getMagnetometerUpdateInterval:(RCTResponseSenderBlock) cb;
-- (void) getMagnetometerData:(RCTResponseSenderBlock) cb;
-- (void) startMagnetometerUpdates:(RCTResponseSenderBlock) cb;
+- (void) getMagnetometerUpdateInterval:(nonnull RCTResponseSenderBlock) cb;
+- (void) getMagnetometerData:(nonnull RCTResponseSenderBlock) cb;
+- (void) startMagnetometerUpdates:(nonnull RCTResponseSenderBlock) cb;
 - (void) stopMagnetometerUpdates;
 
 @end


### PR DESCRIPTION
- Changed CMMotionManager reference to be private readonly property
- Marked RCTResponseSenderBlock parameters nonnull
- Changed property accesses to use modern syntax
- Fixed active reporting, which was the opposite
- Reduced re-getting data objects in get data methods
- Factored out dictionary creation